### PR TITLE
Gdr 2160

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRimport
 Type: Package
 Title: Package for handling the import of dose-response data
-Version: 0.99.21
-Date: 2023-09-14
+Version: 0.99.22
+Date: 2023-09-20
 Authors@R: c(
     person("Arkadiusz", "Gladki", role=c("aut", "cre"), email="gladki.arkadiusz@gmail.com"),
     person("Bartosz", "Czech", role=c("aut")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+#### [0.99.22] - 2023-09-20
+- set barcode as character in the manifest file
+
 #### [0.99.21] - 2023-09-14
 - disable support for 'xls' file format due to crashes
 

--- a/R/load_files.R
+++ b/R/load_files.R
@@ -94,7 +94,13 @@ load_manifest <- function(manifest_file) {
 
   manifest_data <- read_in_manifest_file(manifest_file, available_formats)
   headers <- gDRutils::validate_identifiers(do.call(rbind, manifest_data), req_ids = "barcode")
-
+  
+  # Set character type to barcode
+  manifest_data <- lapply(manifest_data, function(x) {
+    x[, (headers[["barcode"]]) := lapply(.SD, as.character), .SDcols = headers[["barcode"]]]
+  })
+  
+  
   # check default headers are in each df
   dump <- lapply(seq_along(manifest_file),
                  function(i) {


### PR DESCRIPTION
# Description
## What changed?
Set character type to barcode in the manifest
Related JIRA issue: GDR-2160
  
## Why was it changed?
To fix bug when the barcode is represented by number
  
# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
