### PR TITLE
[GDR-2227] Treatment instead of template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRimport
 Type: Package
 Title: Package for handling the import of dose-response data
-Version: 0.99.25
-Date: 2023-10-17
+Version: 0.99.26
+Date: 2023-10-24
 Authors@R: c(
     person("Arkadiusz", "Gladki", role=c("aut", "cre"), email="gladki.arkadiusz@gmail.com"),
     person("Bartosz", "Czech", role=c("aut")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 0.99.26 (2023-10-24)
+- add "Treatment" as template identifier
+
 ## 0.99.25 (2023-10-17)
 - adjust NEWS to Bioc format
 

--- a/R/load_files.R
+++ b/R/load_files.R
@@ -1269,7 +1269,7 @@ check_metadata_headers <- function(corrected_names, df_name) {
     case_match <- setdiff(grep(grep_pattern, corrected_names, ignore.case = TRUE),
                           exact_match_grep)
     if (isTRUE(length(exact_match_grep) == 1 ||
-               corrected_names[case_match] %in% controlled_headers))
+               corrected_names[case_match] %in% unlist(controlled_headers)))
       next
 
     if (length(case_match) > 0) {

--- a/man/load_results.Rd
+++ b/man/load_results.Rd
@@ -27,5 +27,5 @@ This functions loads and checks the results file(s)
 \examples{
  td <- get_test_data()
  r_df <- load_results(result_path(td))
- 
+
 }

--- a/man/load_templates.Rd
+++ b/man/load_templates.Rd
@@ -19,5 +19,5 @@ This functions loads and checks the template file(s)
 \examples{
  td <- get_test_data()
  t_df <- load_templates(template_path(td))
- 
+
 }


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: [GDR-2227](https://jira.gene.com/jira/browse/GDR-2227)
  
## Why was it changed?
`Treatment` is more readable for users than `Template`.
  
# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)
