### PR TITLE
[GDR-2764] Fix invalid moa for PRISM data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRimport
 Type: Package
 Title: Package for handling the import of dose-response data
-Version: 1.5.1
-Date: 2024-11-05
+Version: 1.5.2
+Date: 2024-11-06
 Authors@R: c(
     person("Arkadiusz", "Gladki", role=c("aut", "cre"), email="gladki.arkadiusz@gmail.com",
            comment = c(ORCID = "0000-0002-7059-6378")),
@@ -29,7 +29,7 @@ Imports:
     PharmacoGx,
     data.table,
     futile.logger,
-    gDRutils (>= 1.1.12),
+    gDRutils (>= 1.3.17),
     magrittr,
     methods,
     MultiAssayExperiment,
@@ -47,8 +47,8 @@ Imports:
     openxlsx
 Suggests:
     BiocStyle,
-    gDRtestData (>= 1.1.10),
-    gDRstyle (>= 1.1.5),
+    gDRtestData (>= 1.3.3),
+    gDRstyle (>= 1.3.3),
     knitr,
     purrr,
     qs,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRimport 1.5.2 - 2024-11-06
+* fix invalid moa for PRISM data
+
 ## gDRimport 1.5.1 - 2024-11-05
 * synchronize Bioconductor and GitHub versioning
 

--- a/rplatform/dependencies.yaml
+++ b/rplatform/dependencies.yaml
@@ -1,18 +1,18 @@
 pkgs:
   gDRutils:
-    ver: '>=1.1.12'
+    ver: '>=1.3.17'
     url: gdrplatform/gDRutils
     ref: main
     subdir: ~
     source: GITHUB
   gDRstyle:
-    ver: '>=1.1.5'
+    ver: '>=1.3.3'
     url: gdrplatform/gDRstyle
     ref: main
     subdir: ~
     source: GITHUB
   gDRtestData:
-    ver: '>=1.1.10'
+    ver: '>=1.3.3'
     url: gdrplatform/gDRtestData
     ref: main
     subdir: ~


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue:  [GDR-2764](https://jira.gene.com/jira/browse/GDR-2764)
  
## Why was it changed?
 
Source of bug is in  the `gDRimport::convert_LEVEL6_prism_to_gDR_input` function where 
`
 drug_moa = ifelse(is.null(full_data$moa),
                                                     "unknown",
                                                     full_data$moa)
`
(it returns only first item from full_data$moa - not full vector)

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)
