### PR TITLE
[GDR-2891] Update extracting Tissue for PRISM

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRimport
 Type: Package
 Title: Package for handling the import of dose-response data
-Version: 1.5.7
-Date: 2025-02-07
+Version: 1.5.8
+Date: 2025-02-18
 Authors@R: c(
     person("Arkadiusz", "Gladki", role=c("aut", "cre"), email="gladki.arkadiusz@gmail.com",
            comment = c(ORCID = "0000-0002-7059-6378")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRimport 1.5.8 - 2025-02-18
+* update extracting Tissue information for cell lines in PRISM data
+
 ## gDRimport 1.5.7 - 2025-02-07
 * extract Tissue information for cell lines in PRISM data
 

--- a/R/prism_to_gdrDF.R
+++ b/R/prism_to_gdrDF.R
@@ -57,8 +57,8 @@ convert_LEVEL5_prism_to_gDR_input <- function(prism_data_path,
          data.table::tstrsplit(data$pert_dose, separator, fixed = TRUE, type.convert = TRUE)]
   
   data[, unlist(idfs[c("cellline_name", "cellline_tissue")]) := {
+    cellline_name <- ccle_name
     split_names <- strsplit(ccle_name, "_", fixed = TRUE)
-    cellline_name <- vapply(split_names, function(x) x[1], "")
     cellline_tissue <- vapply(split_names, function(x) paste(x[-1], collapse = "_"), "")
     
     # replace empty strings in cellline_tissue with "unknown"
@@ -199,8 +199,8 @@ convert_LEVEL6_prism_to_gDR_input <- function(prism_data_path,
   }
 
   cell_lines[, unlist(idfs[c("cellline_name", "cellline_tissue")]) := {
+    cellline_name <- ccle_name
     split_names <- strsplit(ccle_name, "_", fixed = TRUE)
-    cellline_name <- vapply(split_names, function(x) x[1], "")
     cellline_tissue <- vapply(split_names, function(x) paste(x[-1], collapse = "_"), "")
     
     # replace empty strings in cellline_tissue with "unknown"

--- a/inst/testdata/prism_sa_2.csv
+++ b/inst/testdata/prism_sa_2.csv
@@ -1,0 +1,3 @@
+rid,ccle_name,culture,pool_id,pert_iname,pert_id,pert_dose,pert_idose,pert_plate,pert_vehicle,pert_time,pert_type,sig_id,x_project_id,LFC,LFC_cb
+c-1_PR?,cl1,PR?,P?,someGnumber,6-85,0.003201,0.003201 ug/mL,sth1,gDRimport,120H,trt_cp,004101814-616-85_0.003201 ug/mL_120H,gDRimport,0.31918439119229997,0.38536262127370596
+c-1_PR?,cl2_ts2,PR?,P?,someGnumber,6-85,0.003201,0.003201 ug/mL,sth1,gDRimport,10 d,trt_cp,004101814-616-85_0.003201 ug/mL_120H,gDRimport,0.31918439119229997,0.38536262127370596

--- a/tests/testthat/test-prism_to_gdrDF.R
+++ b/tests/testthat/test-prism_to_gdrDF.R
@@ -1,5 +1,6 @@
 prism_data <- system.file("testdata/prism_sa.csv", package = "gDRimport")
-prism_data2 <- system.file("testdata/prism_combo.csv", package = "gDRimport")
+prism_data_2 <- system.file("testdata/prism_sa_2.csv", package = "gDRimport")
+prism_data_3 <- system.file("testdata/prism_combo.csv", package = "gDRimport")
 prism_data_path <- system.file("testdata/prism_collapsed_LOGFC.csv", package = "gDRimport")
 cell_line_data_path <- system.file("testdata/prism_cell_lines.csv", package = "gDRimport")
 treatment_data_path <- system.file("testdata/prism_treatment.csv", package = "gDRimport")
@@ -14,10 +15,24 @@ test_that("prism level5 single-agent data can be processed into gDR input format
   expect_equal(df_prism$result$Duration, c(120, 240, 120, 240))
   expect_true(all(gDRutils::get_env_identifiers(c("drug", "cellline"),
                                                 simplify = FALSE) %in% names(df_prism$result)))
+  
+  # testing format of clid, CellLineName and Tissue column
+  expect_equal(df_prism$result$clid, df_prism$result$CellLineName)
+  expect_equal(
+    df_prism$result$Tissue,
+    vapply(df_prism$result$CellLineName, function(x) strsplit(x, "_")[[1]][2], character(1), USE.NAMES = FALSE))
+  
+  df_prism_unknown <- purrr::quietly(convert_LEVEL5_prism_to_gDR_input)(prism_data_2)
+  expect_is(df_prism_unknown$result, "data.table")
+  expect_equal(dim(df_prism_unknown$result), c(4, 12))
+  
+  # testing format of clid, CellLineName and Tissue column
+  expect_equal(df_prism_unknown$result$clid, df_prism_unknown$result$CellLineName)
+  expect_equal(df_prism_unknown$result$Tissue, c("unknown", "ts2", "unknown", "ts2"))
 })
 
 test_that("prism level5 combo data can be processed into gDR input format ", {
-  df_prism <- purrr::quietly(convert_LEVEL5_prism_to_gDR_input)(prism_data2)
+  df_prism <- purrr::quietly(convert_LEVEL5_prism_to_gDR_input)(prism_data_3)
   expect_is(df_prism$result, "data.table")
   expect_equal(dim(df_prism$result), c(2, 14))
   expect_equal(names(df_prism$result), c("clid", "CellLineName", "Tissue", "parental_identifier", "subtype",
@@ -25,6 +40,12 @@ test_that("prism level5 combo data can be processed into gDR input format ", {
                                          "Gnumber", "Gnumber_2", "Concentration", "Concentration_2", "masked"))
   expect_true(all(gDRutils::get_env_identifiers(c("drug", "drug2", "cellline"),
                                                 simplify = FALSE) %in% names(df_prism$result)))
+  
+  # testing format of clid, CellLineName and Tissue column
+  expect_equal(df_prism$result$clid, df_prism$result$CellLineName)
+  expect_equal(
+    df_prism$result$Tissue,
+    vapply(df_prism$result$CellLineName, function(x) strsplit(x, "_")[[1]][2], character(1), USE.NAMES = FALSE))
 })
 
 test_that("prism level6  data can be processed into gDR format ", {
@@ -41,5 +62,10 @@ test_that("prism level6  data can be processed into gDR format ", {
   expect_equal(df_prism[["result"]][[gDRutils::get_env_identifiers("drug")]],
                c("some_drug_name_run1", "some_drug_name_run2", "vehicle"))
   
+  # testing format of clid, CellLineName and Tissue column
+  expect_equal(df_prism$result$clid, df_prism$result$CellLineName)
+  expect_equal(
+    df_prism$result$Tissue,
+    vapply(df_prism$result$CellLineName, function(x) strsplit(x, "_")[[1]][2], character(1), USE.NAMES = FALSE))
 })
 


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: [GDR-2891](https://jira.gene.com/jira/browse/GDR-2891)
  
## Why was it changed?

Because previous version caused errors in the PRISM specific reports.

Previous
| CellLineName | Tissue |
| ---- | ----|
| A375 | SKIN |
| CCLP1 | BILIARY_TRACT |

Current
| CellLineName | Tissue |
| ---- | ----|
| A375_SKIN | SKIN |
| CCLP1_BILIARY_TRACT | BILIARY_TRACT |
  
# Checklist for sustainable code base
- [x] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] NEWS updated

