### PR TITLE
GDR-3366: replace hardcoded Duration values with NA_real_

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRimport
 Type: Package
 Title: Package for handling the import of dose-response data
-Version: 1.9.11
-Date: 2026-04-23
+Version: 1.9.12
+Date: 2026-04-28
 Authors@R: c(
     person("Arkadiusz", "Gladki", role=c("aut", "cre"), email="gladki.arkadiusz@gmail.com",
            comment = c(ORCID = "0000-0002-7059-6378")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRimport 1.9.12 - 2026-04-28
+* replace hardcoded `Duration` values with `NA_real_` in PRISM and PSet importers
+
 ## gDRimport 1.9.11 - 2026-04-23
 * add support for generation of day0 template for tdd files
 

--- a/R/prism_to_gdrDF.R
+++ b/R/prism_to_gdrDF.R
@@ -278,7 +278,7 @@ convert_LEVEL6_prism_to_gDR_input <- function(prism_data_path,
                                     Gnumber = untrt_tag,
                                     DrugName = untrt_tag,
                                     drug_moa = untrt_tag,
-                                    Duration = 120,
+                                    Duration = NA_real_,
                                     Concentration = 0,
                                     ReadoutValue = 1,
                                     masked = FALSE)
@@ -299,7 +299,7 @@ convert_LEVEL6_prism_to_gDR_input <- function(prism_data_path,
   data.table::setnames(dt_trt,
                        old = c("broad_id", "name", "moa", "dose", "value"),
                        new = c("Gnumber", "DrugName", "drug_moa", "Concentration", "ReadoutValue"))
-  dt_trt$Duration <- 120
+  dt_trt$Duration <- NA_real_
   dt_trt$masked <- FALSE
   data.table::setcolorder(dt_trt, neworder = colnames(dt_ctrl))
   

--- a/R/pset_to_gdrDF.R
+++ b/R/pset_to_gdrDF.R
@@ -202,9 +202,8 @@ getPSet <- function(pset_name,
   refDivTime <- gDRutils::get_env_identifiers("cellline_ref_div_time")
   
   
-  # Some datasets do not have duration specified so let's assign any value, since it is required by gDR
   if (!duration %in% names(dt)) {
-    dt[, (duration) := 72]
+    dt[, (duration) := NA_real_]
   }
   if (!refDivTime %in% names(dt)) {
     dt[, (refDivTime) := NA]

--- a/tests/testthat/test-prism_to_gdrDF.R
+++ b/tests/testthat/test-prism_to_gdrDF.R
@@ -61,7 +61,9 @@ test_that("prism level6  data can be processed into gDR format ", {
                                          "subtype", "ReferenceDivisionTime"))
   expect_true(all(gDRutils::get_env_identifiers(c("drug", "cellline"),
                                                 simplify = FALSE) %in% names(df_prism$result)))
-  
+  expect_true(all(is.na(df_prism$result$Duration)))
+  expect_type(df_prism$result$Duration, "double")
+
   # testing format of clid, CellLineName and Tissue column
   expect_equal(df_prism$result$clid, df_prism$result$CellLineName)
   expect_equal(


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-3366

Replaced hardcoded `Duration` values with `NA_real_` in PRISM and PSet importers:
- `prism_to_gdrDF.R`: removed hardcoded `120` for control and treatment data in `convert_LEVEL6_prism_to_gDR_input()`
- `pset_to_gdrDF.R`: removed hardcoded `72` fallback when Duration is missing from PSet data

## Why was it changed?
The hardcoded values (`120` for PRISM level6, `72` for PSets) were arbitrary and factually incorrect — they do not reflect the actual treatment duration from the source data. Using `NA_real_` is semantically honest: the duration is unknown and should not be fabricated.

# Checklist for sustainable code base
- [x] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)