### PR TITLE
chore: sync main with Bioconductor devel (GDR-3372)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gDRimport
 Type: Package
 Title: Package for handling the import of dose-response data
-Version: 1.9.11
+Version: 1.10.0
 Date: 2026-04-23
 Authors@R: c(
     person("Arkadiusz", "Gladki", role=c("aut", "cre"), email="gladki.arkadiusz@gmail.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gDRimport
 Type: Package
 Title: Package for handling the import of dose-response data
-Version: 1.10.0
+Version: 1.11.0
 Date: 2026-04-23
 Authors@R: c(
     person("Arkadiusz", "Gladki", role=c("aut", "cre"), email="gladki.arkadiusz@gmail.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRimport
 Type: Package
 Title: Package for handling the import of dose-response data
-Version: 1.11.0
-Date: 2026-04-23
+Version: 1.11.1
+Date: 2026-04-29
 Authors@R: c(
     person("Arkadiusz", "Gladki", role=c("aut", "cre"), email="gladki.arkadiusz@gmail.com",
            comment = c(ORCID = "0000-0002-7059-6378")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRimport 1.11.1 - 2026-04-29
+* synchronize Bioconductor and GitHub versioning
+
 ## gDRimport 1.9.11 - 2026-04-23
 * add support for generation of day0 template for tdd files
 


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: https://globaljira.roche.com/browse/GDR-3372

Synced `main` branch with Bioconductor `upstream/devel`. Changes: version bumped to 1.11.1, NEWS.md and DESCRIPTION date updated.

## Why was it changed?
Bioconductor created RELEASE_3_23 branch - maintainers required to sync GitHub with Bioconductor git server.

# Checklist for sustainable code base
- [x] I added tests for any code changed/added (N/A - version bump only)
- [x] I added documentation for any code changed/added (N/A)
- [x] I made sure naming of any new functions is self-explanatory and consistent (N/A)

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)