### PR TITLE
fix: fall back to Background section barcode in EnVision parser

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRimport
 Type: Package
 Title: Package for handling the import of dose-response data
-Version: 1.11.3
-Date: 2026-05-27
+Version: 1.11.4
+Date: 2026-06-16
 Authors@R: c(
     person("Arkadiusz", "Gladki", role=c("aut", "cre"), email="gladki.arkadiusz@gmail.com",
            comment = c(ORCID = "0000-0002-7059-6378")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRimport 1.11.4 - 2026-06-16
+* fall back to Background section barcode when Plate header barcode is missing in EnVision files
+
 ## gDRimport 1.11.3 - 2026-05-27
 * apply updated gDRstyle rules
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## gDRimport 1.11.4 - 2026-06-16
-* fall back to Background section barcode when Plate header barcode is missing in EnVision files
+* resolve missing barcode in EnVision files by reading from Background section
 
 ## gDRimport 1.11.3 - 2026-05-27
 * apply updated gDRstyle rules

--- a/R/load_files.R
+++ b/R/load_files.R
@@ -1113,6 +1113,9 @@ get_df_from_raw_edited_EnVision_df <-
       .check_file_structure(df, fname, sheet_name, readout_offset, n_row, n_col, iB, barcode_col)
 
       Barcode <- as.character(df[iB + 1, barcode_col, with = FALSE])
+      if (is.na(Barcode) && ref_bckgrd > 0) {
+        Barcode <- as.character(df[iB + ref_bckgrd + 1, barcode_col, with = FALSE])
+      }
       if (is.na(Barcode)) return(NULL)
       readout <- as.matrix(df[iB + ref_bckgrd + seq_len(n_row) + 1,
                               seq_len(n_col), with = FALSE])

--- a/R/load_files.R
+++ b/R/load_files.R
@@ -1114,7 +1114,8 @@ get_df_from_raw_edited_EnVision_df <-
 
       Barcode <- as.character(df[iB + 1, barcode_col, with = FALSE])
       if (is.na(Barcode) && ref_bckgrd > 0) {
-        Barcode <- as.character(df[iB + ref_bckgrd + 1, barcode_col, with = FALSE])
+        bg_row <- iB + ref_bckgrd + 1
+        Barcode <- as.character(df[bg_row, barcode_col, with = FALSE])
       }
       if (is.na(Barcode)) return(NULL)
       readout <- as.matrix(df[iB + ref_bckgrd + seq_len(n_row) + 1,


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-3439

When parsing EnVision xlsx raw data, if the barcode is missing from the "Plate information" header row, fall back to reading it from the "Background information" section.

## Why was it changed?

Some EnVision exports store the barcode only in the Background section, not in the Plate header. This caused plates to be silently skipped during import (returning NULL), leading to missing data downstream.

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated